### PR TITLE
fix: compile ULOGGER_DISABLE_ALL_LOGS path

### DIFF
--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -28,7 +28,7 @@ namespace Appegy.UniLogger
     public partial class ULogger
     {
 #if ULOGGER_DISABLE_ALL_LOGS
-        private static readonly ULogger _disabledLogger = new ULogger(Config, Tags.Disabled.AsEnumerable());
+        private static readonly ULogger _disabledLogger = new ULogger(Tags.Disabled.AsEnumerable());
 #endif
 
         private static readonly ULogger _unsortedLogger = ULogger.GetLogger(Tags.Unsorted);


### PR DESCRIPTION
The disabled-logger field built the unsorted logger with `new ULogger(Config, ...)`, but `ULogger` has only a single-argument constructor and no `Config` symbol exists, so enabling the `ULOGGER_DISABLE_ALL_LOGS` define broke the build. Drops the stray `Config` argument. Verified the package compiles cleanly with the define enabled (and unchanged without it).