### PR TITLE
test: compile checks for ULOGGER define combinations

### DIFF
--- a/src/Tests/CompileWithDefinesTests.cs
+++ b/src/Tests/CompileWithDefinesTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -14,49 +15,24 @@ namespace Appegy.UniLogger
         private const string TargetAssembly = "Appegy.UniLogger";
         private const string LangVersion = "9.0";
 
-        [Test]
-        public void Compiles_With_AllLogsEnabled()
+        private static IEnumerable<TestCaseData> DefineCombinations()
         {
-            AssertCompiles();
+            yield return Combination("all logs enabled");
+            yield return Combination("trace off", "ULOGGER_TRACE_OFF");
+            yield return Combination("logs off", "ULOGGER_LOGS_OFF");
+            yield return Combination("warnings off", "ULOGGER_WARNINGS_OFF");
+            yield return Combination("errors off", "ULOGGER_ERRORS_OFF");
+            yield return Combination("disable all logs", "ULOGGER_DISABLE_ALL_LOGS");
+            yield return Combination("every level off", "ULOGGER_TRACE_OFF", "ULOGGER_LOGS_OFF", "ULOGGER_WARNINGS_OFF", "ULOGGER_ERRORS_OFF");
         }
 
-        [Test]
-        public void Compiles_With_TraceOff()
+        private static TestCaseData Combination(string name, params string[] defines)
         {
-            AssertCompiles("ULOGGER_TRACE_OFF");
+            return new TestCaseData((object)defines).SetName(name);
         }
 
-        [Test]
-        public void Compiles_With_LogsOff()
-        {
-            AssertCompiles("ULOGGER_LOGS_OFF");
-        }
-
-        [Test]
-        public void Compiles_With_WarningsOff()
-        {
-            AssertCompiles("ULOGGER_WARNINGS_OFF");
-        }
-
-        [Test]
-        public void Compiles_With_ErrorsOff()
-        {
-            AssertCompiles("ULOGGER_ERRORS_OFF");
-        }
-
-        [Test]
-        public void Compiles_With_DisableAllLogs()
-        {
-            AssertCompiles("ULOGGER_DISABLE_ALL_LOGS");
-        }
-
-        [Test]
-        public void Compiles_With_EveryLevelOff()
-        {
-            AssertCompiles("ULOGGER_TRACE_OFF", "ULOGGER_LOGS_OFF", "ULOGGER_WARNINGS_OFF", "ULOGGER_ERRORS_OFF");
-        }
-
-        private static void AssertCompiles(params string[] extraDefines)
+        [TestCaseSource(nameof(DefineCombinations))]
+        public void CompilesWithoutErrorsOrWarnings(string[] extraDefines)
         {
             var assembly = CompilationPipeline.GetAssemblies(AssembliesType.Editor)
                 .FirstOrDefault(c => c.name == TargetAssembly);

--- a/src/Tests/CompileWithDefinesTests.cs
+++ b/src/Tests/CompileWithDefinesTests.cs
@@ -1,0 +1,144 @@
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.Compilation;
+using Assembly = UnityEditor.Compilation.Assembly;
+
+namespace Appegy.UniLogger
+{
+    public class CompileWithDefinesTests
+    {
+        private const string TargetAssembly = "Appegy.UniLogger";
+        private const string LangVersion = "9.0";
+
+        [Test]
+        public void Compiles_With_AllLogsEnabled()
+        {
+            AssertCompiles();
+        }
+
+        [Test]
+        public void Compiles_With_TraceOff()
+        {
+            AssertCompiles("ULOGGER_TRACE_OFF");
+        }
+
+        [Test]
+        public void Compiles_With_LogsOff()
+        {
+            AssertCompiles("ULOGGER_LOGS_OFF");
+        }
+
+        [Test]
+        public void Compiles_With_WarningsOff()
+        {
+            AssertCompiles("ULOGGER_WARNINGS_OFF");
+        }
+
+        [Test]
+        public void Compiles_With_ErrorsOff()
+        {
+            AssertCompiles("ULOGGER_ERRORS_OFF");
+        }
+
+        [Test]
+        public void Compiles_With_DisableAllLogs()
+        {
+            AssertCompiles("ULOGGER_DISABLE_ALL_LOGS");
+        }
+
+        [Test]
+        public void Compiles_With_EveryLevelOff()
+        {
+            AssertCompiles("ULOGGER_TRACE_OFF", "ULOGGER_LOGS_OFF", "ULOGGER_WARNINGS_OFF", "ULOGGER_ERRORS_OFF");
+        }
+
+        private static void AssertCompiles(params string[] extraDefines)
+        {
+            var assembly = CompilationPipeline.GetAssemblies(AssembliesType.Editor)
+                .FirstOrDefault(c => c.name == TargetAssembly);
+            Assert.IsNotNull(assembly, $"Assembly '{TargetAssembly}' was not found.");
+
+            var dotnet = ResolveDotnet();
+            var compiler = ResolveCompiler();
+            if (dotnet == null || compiler == null)
+            {
+                Assert.Ignore("Bundled Roslyn compiler was not found under the editor installation.");
+            }
+
+            var responseFile = Path.Combine("Temp", TargetAssembly + ".compiletest.rsp");
+            File.WriteAllText(responseFile, BuildResponseFile(assembly, extraDefines));
+
+            using var process = new Process
+            {
+                StartInfo =
+                {
+                    FileName = dotnet,
+                    Arguments = $"\"{compiler}\" -noconfig @\"{responseFile}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    WorkingDirectory = Directory.GetCurrentDirectory()
+                }
+            };
+
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            var diagnostics = output
+                .Split('\n')
+                .Select(c => c.Trim())
+                .Where(c => c.Contains(": error CS") || c.Contains(": warning CS"))
+                .ToArray();
+
+            var combo = extraDefines.Length == 0 ? "all logs enabled" : string.Join(", ", extraDefines);
+            Assert.IsEmpty(diagnostics, $"[{combo}] produced compiler diagnostics:\n{string.Join("\n", diagnostics)}");
+        }
+
+        private static string BuildResponseFile(Assembly assembly, string[] extraDefines)
+        {
+            var defines = assembly.defines.Concat(extraDefines).Distinct();
+            var builder = new StringBuilder();
+            builder.AppendLine("-target:library");
+            builder.AppendLine($"-out:\"{Path.Combine("Temp", TargetAssembly + ".compiletest.dll")}\"");
+            builder.AppendLine("-nostdlib+");
+            builder.AppendLine($"-langversion:{LangVersion}");
+            builder.AppendLine($"-define:{string.Join(";", defines)}");
+            foreach (var reference in assembly.allReferences)
+            {
+                builder.AppendLine($"-reference:\"{reference}\"");
+            }
+            foreach (var source in assembly.sourceFiles)
+            {
+                builder.AppendLine($"\"{Path.GetFullPath(source)}\"");
+            }
+            return builder.ToString();
+        }
+
+        private static string ResolveDotnet()
+        {
+            var root = EditorApplication.applicationContentsPath;
+            return new[]
+                {
+                    Path.Combine(root, "NetCoreRuntime", "dotnet.exe"),
+                    Path.Combine(root, "NetCoreRuntime", "dotnet")
+                }
+                .FirstOrDefault(File.Exists);
+        }
+
+        private static string ResolveCompiler()
+        {
+            var root = EditorApplication.applicationContentsPath;
+            return new[]
+                {
+                    Path.Combine(root, "DotNetSdkRoslyn", "csc.dll"),
+                    Path.Combine(root, "Tools", "Roslyn", "csc.dll")
+                }
+                .FirstOrDefault(File.Exists);
+        }
+    }
+}

--- a/src/Tests/CompileWithDefinesTests.cs.meta
+++ b/src/Tests/CompileWithDefinesTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c47c2f16f0246ebfbba1a1c8ef006b05

--- a/src/Tests/FiltererTests.cs
+++ b/src/Tests/FiltererTests.cs
@@ -2,7 +2,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Appegy.UniLogger.Tests
+namespace Appegy.UniLogger
 {
     public class FiltererTests
     {


### PR DESCRIPTION
Adds EditMode tests that compile the `Appegy.UniLogger` assembly under each ULOGGER_* define combination (all-on, each level OFF, every level OFF, and ULOGGER_DISABLE_ALL_LOGS) and fail on any compiler error or warning.

Uses Unity's bundled Roslyn compiler (`DotNetSdkRoslyn/csc.dll` via `NetCoreRuntime/dotnet`) as an external process: no NuGet dependency, no obsolete `AssemblyBuilder`, no domain reload (output goes to Temp and is never loaded), and project scripting-define symbols are left untouched. Source/reference lists come from `CompilationPipeline.GetAssemblies`.

Caveats: assumes C# 9 (`LangVersion` const, matching current Unity) and locates the bundled compiler under the editor install (falls back to Assert.Ignore if not found).