### PR TITLE
refactor: broadcast log context via thread-static struct instead of per-call closure

### DIFF
--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -37,8 +37,7 @@ namespace Appegy.UniLogger
 
         private static readonly ULogger _unsortedLogger = ULogger.GetLogger(Tags.Unsorted);
 
-        [ThreadStatic] private static PendingBroadcast _pending;
-        [ThreadStatic] private static bool _broadcasting;
+        [ThreadStatic] private static PendingBroadcast? _pending;
 
         private struct PendingBroadcast
         {
@@ -101,9 +100,9 @@ namespace Appegy.UniLogger
 
         private static void OnLogMessageReceivedThreaded(string condition, string stacktrace, LogType type)
         {
-            if (_broadcasting)
+            if (_pending.HasValue)
             {
-                var pending = _pending;
+                var pending = _pending.Value;
                 if (string.IsNullOrEmpty(stacktrace))
                 {
                     stacktrace = pending.ManualStacktrace;

--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -36,7 +36,20 @@ namespace Appegy.UniLogger
 #endif
 
         private static readonly ULogger _unsortedLogger = ULogger.GetLogger(Tags.Unsorted);
-        private static Action<string, string, LogType> _logsHandler;
+
+        [ThreadStatic] private static PendingBroadcast _pending;
+        [ThreadStatic] private static bool _broadcasting;
+
+        private struct PendingBroadcast
+        {
+            public ULoggerData Data;
+            public IReadOnlyList<string> Tags;
+            public LogLevel LogLevel;
+            public string Message;
+            public string ManualStacktrace;
+            public Color Color;
+            public UnityEngine.Object Context;
+        }
 
         [CanBeNull]
         private static ULoggerData Data { get; set; }
@@ -88,9 +101,14 @@ namespace Appegy.UniLogger
 
         private static void OnLogMessageReceivedThreaded(string condition, string stacktrace, LogType type)
         {
-            if (_logsHandler != null)
+            if (_broadcasting)
             {
-                _logsHandler(condition, stacktrace, type);
+                var pending = _pending;
+                if (string.IsNullOrEmpty(stacktrace))
+                {
+                    stacktrace = pending.ManualStacktrace;
+                }
+                BroadcastLog(pending.Data, pending.Tags, pending.LogLevel, pending.Message, stacktrace, pending.Color, pending.Context);
             }
             else
             {

--- a/src/Runtime/ULogger.cs
+++ b/src/Runtime/ULogger.cs
@@ -37,18 +37,20 @@ namespace Appegy.UniLogger
                     manualStacktrace = StackTraceUtility.ExtractStackTrace();
                 }
 
-                _logsHandler = onLogReceived;
-                Data.LogHandler.Default.Log(logLevel.ConvertToLogType(), (object)formattedMessage, context);
-                _logsHandler = null;
-
-                void onLogReceived(string condition, string stacktrace, LogType type)
+                _pending = new PendingBroadcast
                 {
-                    if (string.IsNullOrEmpty(stacktrace))
-                    {
-                        stacktrace = manualStacktrace;
-                    }
-                    BroadcastLog(Data, _tags, logLevel, message, stacktrace, color, context);
-                }
+                    Data = Data,
+                    Tags = _tags,
+                    LogLevel = logLevel,
+                    Message = message,
+                    ManualStacktrace = manualStacktrace,
+                    Color = color,
+                    Context = context,
+                };
+                _broadcasting = true;
+                Data.LogHandler.Default.Log(logLevel.ConvertToLogType(), (object)formattedMessage, context);
+                _broadcasting = false;
+                _pending = default;
             }
             // means that this log should not be sent to Unity, but can be sent to other targets
             else

--- a/src/Runtime/ULogger.cs
+++ b/src/Runtime/ULogger.cs
@@ -47,10 +47,8 @@ namespace Appegy.UniLogger
                     Color = color,
                     Context = context,
                 };
-                _broadcasting = true;
                 Data.LogHandler.Default.Log(logLevel.ConvertToLogType(), (object)formattedMessage, context);
-                _broadcasting = false;
-                _pending = default;
+                _pending = null;
             }
             // means that this log should not be sent to Unity, but can be sent to other targets
             else


### PR DESCRIPTION
Per-log broadcast no longer captures call state into a closure (a display-class instance plus a delegate, two heap allocations per log). The context now travels through a `[ThreadStatic]` nullable struct read by the already-subscribed static handler, so the broadcast plumbing is 0-alloc with unchanged behavior. The thread-static field also removes the cross-thread stomp on the old shared `_logsHandler`.