### PR TITLE
fix: deterministic readable tag colors without per-log allocation

### DIFF
--- a/src/Runtime/Services/Formatter.cs
+++ b/src/Runtime/Services/Formatter.cs
@@ -9,7 +9,7 @@ namespace Appegy.UniLogger
         private const float TagColorSaturation = 0.7f;
         private const float TagColorValue = 0.8f;
 
-        private static readonly Dictionary<string, string> _tagColorPrefixes = new Dictionary<string, string>();
+        private static readonly Dictionary<string, string> _tagColorHex = new Dictionary<string, string>();
 
         public FormatOptions FormatOptions { get; set; }
 
@@ -103,7 +103,7 @@ namespace Appegy.UniLogger
                 var tag = line.Tags[i];
                 if (RichText)
                 {
-                    builder.Append(GetTagColorPrefix(tag));
+                    AppendTagColorOpenTag(builder, tag);
                     builder.Append("[");
                     builder.Append(tag);
                     builder.Append("]</color>");
@@ -137,18 +137,25 @@ namespace Appegy.UniLogger
             }
         }
 
-        private static string GetTagColorPrefix(string tag)
+        private static void AppendTagColorOpenTag(StringBuilder builder, string tag)
         {
-            lock (_tagColorPrefixes)
+            builder.Append("<color=#");
+            builder.Append(GetTagColorHex(tag));
+            builder.Append(">");
+        }
+
+        private static string GetTagColorHex(string tag)
+        {
+            lock (_tagColorHex)
             {
-                if (_tagColorPrefixes.TryGetValue(tag, out var prefix)) return prefix;
+                if (_tagColorHex.TryGetValue(tag, out var hex)) return hex;
 
                 var hue = (StableHash(tag) & 0xFFFFFF) / (float)0x1000000;
                 var color = Color.HSVToRGB(hue, TagColorSaturation, TagColorValue);
-                prefix = "<color=#" + ColorUtility.ToHtmlStringRGBA(color) + ">";
+                hex = ColorUtility.ToHtmlStringRGBA(color);
 
-                _tagColorPrefixes[tag] = prefix;
-                return prefix;
+                _tagColorHex[tag] = hex;
+                return hex;
             }
         }
 

--- a/src/Runtime/Services/Formatter.cs
+++ b/src/Runtime/Services/Formatter.cs
@@ -6,7 +6,10 @@ namespace Appegy.UniLogger
 {
     public class Formatter
     {
-        private static readonly Dictionary<string, Color> _coloredCategories = new Dictionary<string, Color>();
+        private const float TagColorSaturation = 0.7f;
+        private const float TagColorValue = 0.8f;
+
+        private static readonly Dictionary<string, string> _tagColorPrefixes = new Dictionary<string, string>();
 
         public FormatOptions FormatOptions { get; set; }
 
@@ -100,9 +103,7 @@ namespace Appegy.UniLogger
                 var tag = line.Tags[i];
                 if (RichText)
                 {
-                    builder.Append("<color=#");
-                    builder.Append(ColorUtility.ToHtmlStringRGBA(GetColor(tag)));
-                    builder.Append(">");
+                    builder.Append(GetTagColorPrefix(tag));
                     builder.Append("[");
                     builder.Append(tag);
                     builder.Append("]</color>");
@@ -136,30 +137,32 @@ namespace Appegy.UniLogger
             }
         }
 
-        private static Color GetColor(string tag)
+        private static string GetTagColorPrefix(string tag)
         {
-            // TODO Create Tag class with Name and Color and cache Color on logger creation
-            Color color;
-            lock (_coloredCategories)
+            lock (_tagColorPrefixes)
             {
-                if (_coloredCategories.TryGetValue(tag, out color)) return color;
-                var seed = tag.GetHashCode();
-                var rnd = new System.Random(seed);
+                if (_tagColorPrefixes.TryGetValue(tag, out var prefix)) return prefix;
 
-                // TODO find convenient parameters for generating colors for both light and dark themes
-                var h = GetRandomNumberInRange(rnd, 0.4f, 0.6f);
-                var s = GetRandomNumberInRange(rnd, 0.9f, 1.0f);
-                var v = GetRandomNumberInRange(rnd, 0.0f, 1.0f);
+                var hue = (StableHash(tag) & 0xFFFFFF) / (float)0x1000000;
+                var color = Color.HSVToRGB(hue, TagColorSaturation, TagColorValue);
+                prefix = "<color=#" + ColorUtility.ToHtmlStringRGBA(color) + ">";
 
-                color = Color.HSVToRGB(h, s, v);
-                _coloredCategories[tag] = color;
+                _tagColorPrefixes[tag] = prefix;
+                return prefix;
             }
-            return color;
         }
 
-        private static float GetRandomNumberInRange(System.Random rnd, float minNumber, float maxNumber)
+        private static uint StableHash(string tag)
         {
-            return (float)(rnd.NextDouble() * (maxNumber - minNumber) + minNumber);
+            const uint offsetBasis = 2166136261;
+            const uint prime = 16777619;
+            var hash = offsetBasis;
+            for (var i = 0; i < tag.Length; i++)
+            {
+                hash ^= tag[i];
+                hash *= prime;
+            }
+            return hash;
         }
     }
 }


### PR DESCRIPTION
Tag colors were seeded from `string.GetHashCode()` (randomized per process) via `new System.Random`, so a tag's color changed between runs and platforms, the hue was confined to a blue-green band, and value could reach near-black. Colors now derive from a stable FNV-1a hash spread across the full hue spectrum at fixed saturation/value, with no `Random` allocation. The cache stores the ready `<color=#RRGGBBAA>` prefix per tag, removing the `ToHtmlStringRGBA` allocation on every richtext log.