### PR TITLE
fix: build LogTypes from LogLevel values instead of LogType

### DIFF
--- a/src/Runtime/Types/LogLevel.cs
+++ b/src/Runtime/Types/LogLevel.cs
@@ -16,7 +16,7 @@ namespace Appegy.UniLogger
 
     public static class LogLevelExtensions
     {
-        public static readonly IReadOnlyList<LogLevel> LogTypes = Enum.GetValues(typeof(LogType)).Cast<LogLevel>().ToArray();
+        public static readonly IReadOnlyList<LogLevel> LogTypes = Enum.GetValues(typeof(LogLevel)).Cast<LogLevel>().ToArray();
 
         public static LogLevel ConvertToLogLevel(this LogType original)
         {


### PR DESCRIPTION
`LogTypes` enumerated `typeof(LogType)` and cast the values to `LogLevel`, which only produced the right set because both enums happen to have five contiguous values 0-4. It now enumerates `typeof(LogLevel)` directly. The resulting array is identical, so behavior is unchanged.