### PR TITLE
refactor: single-tag logger constructor to skip distinct/sort/tolist

### DIFF
--- a/src/Runtime/Tag/TagsHelper.cs
+++ b/src/Runtime/Tag/TagsHelper.cs
@@ -8,11 +8,6 @@ namespace Appegy.UniLogger
         private static readonly Dictionary<Type, string> _tagTypesCache = new Dictionary<Type, string>();
         private static readonly Dictionary<Enum, string> _tagEnumsCache = new Dictionary<Enum, string>();
 
-        public static IEnumerable<T> AsEnumerable<T>(this T item)
-        {
-            yield return item;
-        }
-
         public static string GetTag(this object tag)
         {
             return tag switch

--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -29,10 +29,10 @@ namespace Appegy.UniLogger
     public partial class ULogger
     {
 #if ULOGGER_DISABLE_ALL_LOGS
-        private static readonly ULogger _disabledLogger = new ULogger(Tags.Disabled.AsEnumerable());
+        private static readonly ULogger _disabledLogger = new ULogger(Tags.Disabled);
 #else
         private static readonly ConcurrentDictionary<string, ULogger> _loggersByTag = new ConcurrentDictionary<string, ULogger>();
-        private static readonly Func<string, ULogger> _loggerFactory = tag => new ULogger(tag.AsEnumerable());
+        private static readonly Func<string, ULogger> _loggerFactory = tag => new ULogger(tag);
 #endif
 
         private static readonly ULogger _unsortedLogger = ULogger.GetLogger(Tags.Unsorted);

--- a/src/Runtime/ULogger.cs
+++ b/src/Runtime/ULogger.cs
@@ -8,6 +8,11 @@ namespace Appegy.UniLogger
     {
         private readonly IReadOnlyList<string> _tags;
 
+        internal ULogger(string tag)
+        {
+            _tags = new[] { tag };
+        }
+
         internal ULogger(IEnumerable<string> tags)
         {
             _tags = tags.Distinct().OrderBy(c => c).ToList();


### PR DESCRIPTION
Every cached logger is created from a single tag, yet the constructor ran `Distinct().OrderBy().ToList()` (~456 B per cache miss) which is a no-op for one element. Added a single-tag constructor that stores a one-element array directly; the logger factory and the disabled logger use it. Removed the now-unused `AsEnumerable` helper.