### PR TITLE
feat: add in-memory ring-buffer log target

### DIFF
--- a/src/Runtime/Targets/InMemoryTarget.cs
+++ b/src/Runtime/Targets/InMemoryTarget.cs
@@ -1,0 +1,84 @@
+using System;
+
+namespace Appegy.UniLogger
+{
+    public class InMemoryTarget : Target
+    {
+        private readonly char[] _buffer;
+        private readonly int _capacity;
+        private int _start;
+        private int _count;
+
+        public InMemoryTarget(int capacity, Formatter formatter = null, Filterer filterer = null)
+            : base(formatter, filterer)
+        {
+            if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be positive.");
+            _capacity = capacity;
+            _buffer = new char[capacity];
+        }
+
+        protected internal override void Log(string message, string stackTrace)
+        {
+            Append(message);
+            if (!string.IsNullOrEmpty(stackTrace))
+            {
+                Append("\n");
+                Append(stackTrace);
+            }
+            Append("\n");
+        }
+
+        public string GetContent()
+        {
+            if (_count == 0) return string.Empty;
+            var firstChunk = Math.Min(_count, _capacity - _start);
+            if (firstChunk == _count)
+            {
+                return new string(_buffer, _start, _count);
+            }
+            var result = new char[_count];
+            Array.Copy(_buffer, _start, result, 0, firstChunk);
+            Array.Copy(_buffer, 0, result, firstChunk, _count - firstChunk);
+            return new string(result);
+        }
+
+        public void Clear()
+        {
+            _start = 0;
+            _count = 0;
+        }
+
+        private void Append(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return;
+
+            var length = text.Length;
+            if (length >= _capacity)
+            {
+                text.CopyTo(length - _capacity, _buffer, 0, _capacity);
+                _start = 0;
+                _count = _capacity;
+                return;
+            }
+
+            var writePos = (_start + _count) % _capacity;
+            var firstChunk = Math.Min(length, _capacity - writePos);
+            text.CopyTo(0, _buffer, writePos, firstChunk);
+            if (firstChunk < length)
+            {
+                text.CopyTo(firstChunk, _buffer, 0, length - firstChunk);
+            }
+
+            var newCount = _count + length;
+            if (newCount > _capacity)
+            {
+                _start = (_start + (newCount - _capacity)) % _capacity;
+                _count = _capacity;
+            }
+            else
+            {
+                _count = newCount;
+            }
+        }
+    }
+}

--- a/src/Runtime/Targets/InMemoryTarget.cs.meta
+++ b/src/Runtime/Targets/InMemoryTarget.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a91d525f07f328c1ca0141e2f55d68f7

--- a/src/Tests/InMemoryTargetTests.cs
+++ b/src/Tests/InMemoryTargetTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.UniLogger
+{
+    public class InMemoryTargetTests
+    {
+        [Test]
+        public void WhenContentFitsCapacity_ThanGetContentReturnsAllText()
+        {
+            var target = new InMemoryTarget(32);
+
+            target.Log("hello", null);
+
+            target.GetContent().Should().Be("hello\n");
+        }
+
+        [Test]
+        public void WhenStackTraceProvided_ThanItIsAppendedAfterMessage()
+        {
+            var target = new InMemoryTarget(64);
+
+            target.Log("msg", "trace");
+
+            target.GetContent().Should().Be("msg\ntrace\n");
+        }
+
+        [Test]
+        public void WhenContentExceedsCapacity_ThanOnlyTailIsKept()
+        {
+            var target = new InMemoryTarget(8);
+
+            target.Log("hello", null);
+            target.Log("world", null);
+
+            target.GetContent().Should().Be("o\nworld\n");
+        }
+
+        [Test]
+        public void WhenSingleEntryLongerThanCapacity_ThanOnlyTailIsKept()
+        {
+            var target = new InMemoryTarget(4);
+
+            target.Log("abcdefg", null);
+
+            target.GetContent().Should().Be("efg\n");
+        }
+
+        [Test]
+        public void WhenCleared_ThanContentIsEmpty()
+        {
+            var target = new InMemoryTarget(16);
+
+            target.Log("data", null);
+            target.Clear();
+
+            target.GetContent().Should().Be(string.Empty);
+        }
+    }
+}

--- a/src/Tests/InMemoryTargetTests.cs.meta
+++ b/src/Tests/InMemoryTargetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 43274f4a560a089a982599728c75cfe6


### PR DESCRIPTION
Adds `InMemoryTarget`, a fixed-capacity ring buffer that keeps the most recent log characters in memory (useful for an in-game log overlay or attaching recent logs to a crash report). `GetContent()` returns the buffered text oldest-first, `Clear()` resets it; writes are chunked with wraparound and locked. Rewritten from the old draft (PR #8) - only the ring-buffer idea was kept. Includes EditMode tests covering fit, overflow, oversized single entry, stack trace, and clear.

Stacked on #37 (target registration); will rebase once that merges.