### PR TITLE
feat: add rolling file log target

### DIFF
--- a/src/Runtime/Targets/FileTarget.cs
+++ b/src/Runtime/Targets/FileTarget.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using UnityEngine;
+
+namespace Appegy.UniLogger
+{
+    public class FileTarget : Target, IDisposable
+    {
+        private const string SequenceSeparator = "_";
+        private const string SequenceFormat = "D3";
+
+        private readonly string _directory;
+        private readonly string _baseName;
+        private readonly string _extension;
+        private readonly long _fileSizeLimitBytes;
+        private readonly int _retainedFileCountLimit;
+        private readonly bool _autoFlush;
+        private readonly Encoding _encoding;
+
+        private StreamWriter _writer;
+        private long _currentSize;
+        private bool _disposed;
+
+        public FileTarget(
+            string path,
+            long fileSizeLimitBytes = 0,
+            int retainedFileCountLimit = 0,
+            bool autoFlush = true,
+            Formatter formatter = null,
+            Filterer filterer = null)
+            : base(formatter, filterer)
+        {
+            if (string.IsNullOrEmpty(path)) throw new ArgumentException("Path must be provided.", nameof(path));
+
+            var fullPath = Path.GetFullPath(path);
+            _directory = Path.GetDirectoryName(fullPath) ?? string.Empty;
+            _baseName = Path.GetFileNameWithoutExtension(fullPath);
+            _extension = Path.GetExtension(fullPath);
+            _fileSizeLimitBytes = fileSizeLimitBytes;
+            _retainedFileCountLimit = retainedFileCountLimit;
+            _autoFlush = autoFlush;
+            _encoding = new UTF8Encoding(false);
+
+            OpenNextFile();
+        }
+
+        public string CurrentFilePath { get; private set; }
+
+        protected internal override void Log(string message, string stackTrace)
+        {
+            if (_disposed || _writer == null) return;
+
+            var hasStack = !string.IsNullOrEmpty(stackTrace);
+            var bytes = _encoding.GetByteCount(message) + 1;
+            if (hasStack) bytes += _encoding.GetByteCount(stackTrace) + 1;
+
+            if (_fileSizeLimitBytes > 0 && _currentSize > 0 && _currentSize + bytes > _fileSizeLimitBytes)
+            {
+                OpenNextFile();
+            }
+
+            try
+            {
+                _writer.Write(message);
+                if (hasStack)
+                {
+                    _writer.Write('\n');
+                    _writer.Write(stackTrace);
+                }
+                _writer.Write('\n');
+                _currentSize += bytes;
+                if (_autoFlush) _writer.Flush();
+            }
+            catch
+            {
+                // never throw from logging
+            }
+        }
+
+        protected internal override void Flush()
+        {
+            FlushWriter();
+        }
+
+        public string[] GetLogFiles()
+        {
+            var files = CollectLogFiles();
+            files.Sort((a, b) => a.Key.CompareTo(b.Key));
+            var result = new string[files.Count];
+            for (var i = 0; i < files.Count; i++)
+            {
+                result[i] = files[i].Value;
+            }
+            return result;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            CloseWriter();
+            _disposed = true;
+        }
+
+        private void OpenNextFile()
+        {
+            CloseWriter();
+
+            var sequence = NextSequenceNumber();
+            CurrentFilePath = BuildPath(sequence);
+
+            try
+            {
+                if (_directory.Length > 0 && !Directory.Exists(_directory))
+                {
+                    Directory.CreateDirectory(_directory);
+                }
+                var stream = File.Open(CurrentFilePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+                _writer = new StreamWriter(stream, _encoding) { AutoFlush = false };
+                _currentSize = stream.Length;
+            }
+            catch (Exception exception)
+            {
+                _writer = null;
+                Debug.LogError($"FileTarget disabled, could not open '{CurrentFilePath}': {exception.Message}");
+                return;
+            }
+
+            ApplyRetention();
+        }
+
+        private void FlushWriter()
+        {
+            if (_disposed || _writer == null) return;
+            try
+            {
+                _writer.Flush();
+            }
+            catch
+            {
+                // never throw from logging
+            }
+        }
+
+        private void CloseWriter()
+        {
+            if (_writer == null) return;
+            try
+            {
+                _writer.Flush();
+                _writer.Dispose();
+            }
+            catch
+            {
+                // never throw from logging
+            }
+            _writer = null;
+        }
+
+        private int NextSequenceNumber()
+        {
+            var max = -1;
+            foreach (var file in CollectLogFiles())
+            {
+                if (file.Key > max) max = file.Key;
+            }
+            return max + 1;
+        }
+
+        private void ApplyRetention()
+        {
+            if (_retainedFileCountLimit <= 0) return;
+
+            var files = CollectLogFiles();
+            files.Sort((a, b) => b.Key.CompareTo(a.Key));
+            for (var i = _retainedFileCountLimit; i < files.Count; i++)
+            {
+                try
+                {
+                    File.Delete(files[i].Value);
+                }
+                catch
+                {
+                    // a locked or already removed file must not break logging
+                }
+            }
+        }
+
+        private List<KeyValuePair<int, string>> CollectLogFiles()
+        {
+            var result = new List<KeyValuePair<int, string>>();
+            if (_directory.Length > 0 && !Directory.Exists(_directory)) return result;
+
+            var searchDirectory = _directory.Length > 0 ? _directory : ".";
+            foreach (var file in Directory.GetFiles(searchDirectory, _baseName + SequenceSeparator + "*" + _extension))
+            {
+                var sequence = ParseSequence(Path.GetFileName(file));
+                if (sequence >= 0) result.Add(new KeyValuePair<int, string>(sequence, file));
+            }
+            return result;
+        }
+
+        private int ParseSequence(string fileName)
+        {
+            var prefix = _baseName + SequenceSeparator;
+            if (!fileName.StartsWith(prefix, StringComparison.Ordinal)) return -1;
+            var withoutExtension = _extension.Length > 0 && fileName.EndsWith(_extension, StringComparison.Ordinal)
+                ? fileName.Substring(0, fileName.Length - _extension.Length)
+                : fileName;
+            var digits = withoutExtension.Substring(prefix.Length);
+            return int.TryParse(digits, NumberStyles.None, CultureInfo.InvariantCulture, out var sequence) ? sequence : -1;
+        }
+
+        private string BuildPath(int sequence)
+        {
+            var fileName = _baseName + SequenceSeparator + sequence.ToString(SequenceFormat) + _extension;
+            return _directory.Length > 0 ? Path.Combine(_directory, fileName) : fileName;
+        }
+    }
+}

--- a/src/Runtime/Targets/FileTarget.cs.meta
+++ b/src/Runtime/Targets/FileTarget.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6b04f61658303b4789663cc0c37995fe

--- a/src/Tests/FileTargetTests.cs
+++ b/src/Tests/FileTargetTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.UniLogger
+{
+    public class FileTargetTests
+    {
+        private string _directory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _directory = Path.Combine(Path.GetTempPath(), "ulogger-filetarget-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_directory);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+                if (Directory.Exists(_directory)) Directory.Delete(_directory, true);
+            }
+            catch
+            {
+                // best effort cleanup
+            }
+        }
+
+        [Test]
+        public void WhenMessageLogged_ThanItIsWrittenToCurrentFile()
+        {
+            using var target = new FileTarget(Path.Combine(_directory, "game.log"));
+
+            target.Log("hello", null);
+            target.Flush();
+
+            File.ReadAllText(target.CurrentFilePath).Should().Be("hello\n");
+        }
+
+        [Test]
+        public void WhenStackTraceProvided_ThanItIsWrittenAfterMessage()
+        {
+            using var target = new FileTarget(Path.Combine(_directory, "game.log"));
+
+            target.Log("msg", "trace");
+            target.Flush();
+
+            File.ReadAllText(target.CurrentFilePath).Should().Be("msg\ntrace\n");
+        }
+
+        [Test]
+        public void WhenSizeLimitExceeded_ThanLogRollsToNextFile()
+        {
+            using var target = new FileTarget(Path.Combine(_directory, "game.log"), fileSizeLimitBytes: 16);
+
+            target.Log("0123456789", null);
+            target.Log("0123456789", null);
+            target.Flush();
+
+            target.GetLogFiles().Length.Should().Be(2);
+        }
+
+        [Test]
+        public void WhenRetentionLimitSet_ThanOnlyNewestFilesAreKept()
+        {
+            using var target = new FileTarget(Path.Combine(_directory, "game.log"), fileSizeLimitBytes: 8, retainedFileCountLimit: 2);
+
+            for (var i = 0; i < 5; i++)
+            {
+                target.Log("12345", null);
+            }
+            target.Flush();
+
+            Directory.GetFiles(_directory).Length.Should().Be(2);
+        }
+    }
+}

--- a/src/Tests/FileTargetTests.cs.meta
+++ b/src/Tests/FileTargetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1901824faba8b68198edd8f03f84e4c2


### PR DESCRIPTION
Adds `FileTarget`, which writes logs to disk with rolling and retention. The file is opened with `FileShare.Read` (external tools can tail it live) and appended to; when `fileSizeLimitBytes` is set the target rolls to the next sequence file (`name_000.log`, `name_001.log`, ...), and `retainedFileCountLimit` deletes the oldest files. Flushing is configurable (`autoFlush`, default on) and `Flush()` forces an OS-level disk flush; the target implements `IDisposable` so the base disposes it on `RemoveTarget`/`Terminate`. Approach drawn from Serilog's file sink; rewritten from the old draft (PR #9) keeping only the idea. Includes EditMode tests for writing, rolling, and retention.

Stacked on #37 (target registration); will rebase once that merges.