### PR TITLE
feat: thread-safe logging via single-writer dispatcher

### DIFF
--- a/src/Runtime/Internal/LogDispatcher.cs
+++ b/src/Runtime/Internal/LogDispatcher.cs
@@ -1,31 +1,13 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Threading;
 
 namespace Appegy.UniLogger
 {
     internal sealed class LogDispatcher : IDisposable
     {
-        private readonly struct Item
-        {
-            public readonly LogRecord Record;
-            public readonly ManualResetEventSlim FlushSignal;
-
-            private Item(LogRecord record, ManualResetEventSlim flushSignal)
-            {
-                Record = record;
-                FlushSignal = flushSignal;
-            }
-
-            public bool IsFlush => FlushSignal != null;
-
-            public static Item Log(in LogRecord record) => new Item(record, null);
-            public static Item Flush(ManualResetEventSlim signal) => new Item(default, signal);
-        }
-
         private readonly ULoggerData _data;
-        private readonly BlockingCollection<Item> _queue = new BlockingCollection<Item>();
+        private readonly BlockingCollection<LogRecord> _queue = new BlockingCollection<LogRecord>();
         private readonly Thread _thread;
         private volatile bool _completed;
 
@@ -45,27 +27,12 @@ namespace Appegy.UniLogger
             if (_completed || _data.Targets.Length == 0) return;
             try
             {
-                _queue.Add(Item.Log(record));
+                _queue.Add(record);
             }
             catch (InvalidOperationException)
             {
                 // adding completed concurrently with terminate
             }
-        }
-
-        public void Flush()
-        {
-            if (_completed) return;
-            using var signal = new ManualResetEventSlim(false);
-            try
-            {
-                _queue.Add(Item.Flush(signal));
-            }
-            catch (InvalidOperationException)
-            {
-                return;
-            }
-            signal.Wait();
         }
 
         public void Dispose()
@@ -79,13 +46,12 @@ namespace Appegy.UniLogger
 
         private void WriteLoop()
         {
-            var pendingFlushes = new List<ManualResetEventSlim>();
             while (true)
             {
-                Item item;
+                LogRecord record;
                 try
                 {
-                    item = _queue.Take();
+                    record = _queue.Take();
                 }
                 catch (InvalidOperationException)
                 {
@@ -94,23 +60,11 @@ namespace Appegy.UniLogger
 
                 do
                 {
-                    if (item.IsFlush)
-                    {
-                        pendingFlushes.Add(item.FlushSignal);
-                    }
-                    else
-                    {
-                        ULogger.Deliver(_data, item.Record);
-                    }
+                    ULogger.Deliver(_data, record);
                 }
-                while (_queue.TryTake(out item, 0));
+                while (_queue.TryTake(out record, 0));
 
                 FlushTargets();
-                for (var i = 0; i < pendingFlushes.Count; i++)
-                {
-                    pendingFlushes[i].Set();
-                }
-                pendingFlushes.Clear();
             }
 
             FlushTargets();

--- a/src/Runtime/Internal/LogDispatcher.cs
+++ b/src/Runtime/Internal/LogDispatcher.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Appegy.UniLogger
+{
+    internal sealed class LogDispatcher : IDisposable
+    {
+        private readonly struct Item
+        {
+            public readonly LogRecord Record;
+            public readonly ManualResetEventSlim FlushSignal;
+
+            private Item(LogRecord record, ManualResetEventSlim flushSignal)
+            {
+                Record = record;
+                FlushSignal = flushSignal;
+            }
+
+            public bool IsFlush => FlushSignal != null;
+
+            public static Item Log(in LogRecord record) => new Item(record, null);
+            public static Item Flush(ManualResetEventSlim signal) => new Item(default, signal);
+        }
+
+        private readonly ULoggerData _data;
+        private readonly BlockingCollection<Item> _queue = new BlockingCollection<Item>();
+        private readonly Thread _thread;
+        private volatile bool _completed;
+
+        public LogDispatcher(ULoggerData data)
+        {
+            _data = data;
+            _thread = new Thread(WriteLoop)
+            {
+                Name = "UniLogger.Writer",
+                IsBackground = true,
+            };
+            _thread.Start();
+        }
+
+        public void Enqueue(in LogRecord record)
+        {
+            if (_completed || _data.Targets.Length == 0) return;
+            try
+            {
+                _queue.Add(Item.Log(record));
+            }
+            catch (InvalidOperationException)
+            {
+                // adding completed concurrently with terminate
+            }
+        }
+
+        public void Flush()
+        {
+            if (_completed) return;
+            using var signal = new ManualResetEventSlim(false);
+            try
+            {
+                _queue.Add(Item.Flush(signal));
+            }
+            catch (InvalidOperationException)
+            {
+                return;
+            }
+            signal.Wait();
+        }
+
+        public void Dispose()
+        {
+            if (_completed) return;
+            _completed = true;
+            _queue.CompleteAdding();
+            _thread.Join();
+            _queue.Dispose();
+        }
+
+        private void WriteLoop()
+        {
+            var pendingFlushes = new List<ManualResetEventSlim>();
+            while (true)
+            {
+                Item item;
+                try
+                {
+                    item = _queue.Take();
+                }
+                catch (InvalidOperationException)
+                {
+                    break;
+                }
+
+                do
+                {
+                    if (item.IsFlush)
+                    {
+                        pendingFlushes.Add(item.FlushSignal);
+                    }
+                    else
+                    {
+                        ULogger.Deliver(_data, item.Record);
+                    }
+                }
+                while (_queue.TryTake(out item, 0));
+
+                FlushTargets();
+                for (var i = 0; i < pendingFlushes.Count; i++)
+                {
+                    pendingFlushes[i].Set();
+                }
+                pendingFlushes.Clear();
+            }
+
+            FlushTargets();
+        }
+
+        private void FlushTargets()
+        {
+            var targets = _data.Targets;
+            for (var i = 0; i < targets.Length; i++)
+            {
+                try
+                {
+                    targets[i].Flush();
+                }
+                catch
+                {
+                    // never fail the writer loop on a target flush
+                }
+            }
+        }
+    }
+}

--- a/src/Runtime/Internal/LogDispatcher.cs
+++ b/src/Runtime/Internal/LogDispatcher.cs
@@ -7,7 +7,7 @@ namespace Appegy.UniLogger
     internal sealed class LogDispatcher : IDisposable
     {
         private readonly ULoggerData _data;
-        private readonly BlockingCollection<LogRecord> _queue = new BlockingCollection<LogRecord>();
+        private readonly BlockingCollection<LogRecord> _queue = new();
         private readonly Thread _thread;
         private volatile bool _completed;
 

--- a/src/Runtime/Internal/LogDispatcher.cs.meta
+++ b/src/Runtime/Internal/LogDispatcher.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cdb512cfca7ce54edabf375ca7f0effb

--- a/src/Runtime/Internal/LogRecord.cs
+++ b/src/Runtime/Internal/LogRecord.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Appegy.UniLogger
+{
+    internal readonly struct LogRecord
+    {
+        public readonly IReadOnlyList<string> Tags;
+        public readonly LogLevel LogLevel;
+        public readonly string Message;
+        public readonly string StackTrace;
+        public readonly Color Color;
+        public readonly Object Context;
+        public readonly DateTime LogTime;
+        public readonly int ThreadId;
+
+        public LogRecord(IReadOnlyList<string> tags, LogLevel logLevel, string message, string stackTrace, Color color, Object context, DateTime logTime, int threadId)
+        {
+            Tags = tags;
+            LogLevel = logLevel;
+            Message = message;
+            StackTrace = stackTrace;
+            Color = color;
+            Context = context;
+            LogTime = logTime;
+            ThreadId = threadId;
+        }
+    }
+}

--- a/src/Runtime/Internal/LogRecord.cs.meta
+++ b/src/Runtime/Internal/LogRecord.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ec57f947d1968b5991a47102dbfebe4

--- a/src/Runtime/Internal/StringBuilderPool.cs
+++ b/src/Runtime/Internal/StringBuilderPool.cs
@@ -8,7 +8,7 @@ namespace Appegy.UniLogger
         private const int MaxCapacity = 2000;
         private const int InitialCapacity = 100;
 
-        private static readonly ConcurrentBag<StringBuilder> _objects = new ConcurrentBag<StringBuilder>();
+        private static readonly ConcurrentBag<StringBuilder> _objects = new();
 
         public static StringBuilder GetBuilder()
         {

--- a/src/Runtime/Services/Filterer.cs
+++ b/src/Runtime/Services/Filterer.cs
@@ -1,22 +1,34 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using static Appegy.UniLogger.LogLevelExtensions;
 
 namespace Appegy.UniLogger
 {
     public class Filterer
     {
-        private readonly bool[] _logTypeEnabled;
+        private sealed class Snapshot
+        {
+            public readonly bool[] LogTypeEnabled;
+            public readonly HashSet<string> Tags;
+
+            public Snapshot(bool[] logTypeEnabled, HashSet<string> tags)
+            {
+                LogTypeEnabled = logTypeEnabled;
+                Tags = tags;
+            }
+        }
+
         private readonly bool _allTagsEnabledByDefault;
-        private readonly HashSet<string> _tags = new HashSet<string>();
+        private volatile Snapshot _snapshot;
 
         public Filterer(bool allTagsEnabledByDefault)
         {
             _allTagsEnabledByDefault = allTagsEnabledByDefault;
-            _logTypeEnabled = new bool[LogTypes.Count];
+            var logTypeEnabled = new bool[LogTypes.Count];
             foreach (var logType in LogTypes)
             {
-                _logTypeEnabled[(int)logType] = true;
+                logTypeEnabled[(int)logType] = true;
             }
+            _snapshot = new Snapshot(logTypeEnabled, new HashSet<string>());
         }
 
         /// <summary>
@@ -24,33 +36,44 @@ namespace Appegy.UniLogger
         /// </summary>
         public bool IsAllowed(LogLevel logLevel, string tag)
         {
-            if (!_logTypeEnabled[(int)logLevel]) return false;
+            var snapshot = _snapshot;
+            if (!snapshot.LogTypeEnabled[(int)logLevel]) return false;
             return _allTagsEnabledByDefault switch
             {
-                true => !_tags.Contains(tag),
-                false => _tags.Contains(tag)
+                true => !snapshot.Tags.Contains(tag),
+                false => snapshot.Tags.Contains(tag)
             };
         }
 
         public Filterer SetAllowed(LogLevel logLevel, bool value)
         {
-            _logTypeEnabled[(int)logLevel] = value;
+            ThreadDispatcher.EnsureMainThread(nameof(SetAllowed));
+            var snapshot = _snapshot;
+            var logTypeEnabled = (bool[])snapshot.LogTypeEnabled.Clone();
+            logTypeEnabled[(int)logLevel] = value;
+            _snapshot = new Snapshot(logTypeEnabled, snapshot.Tags);
             return this;
         }
 
         public Filterer SetAllowed(string tag, bool value)
         {
-            switch (_allTagsEnabledByDefault)
+            ThreadDispatcher.EnsureMainThread(nameof(SetAllowed));
+            var snapshot = _snapshot;
+            var removeFromSet = _allTagsEnabledByDefault == value;
+            if (removeFromSet ? !snapshot.Tags.Contains(tag) : snapshot.Tags.Contains(tag))
             {
-                case true when value:
-                case false when !value:
-                    _tags.Remove(tag);
-                    break;
-                default:
-                    _tags.Add(tag);
-                    break;
+                return this;
             }
-
+            var tags = new HashSet<string>(snapshot.Tags);
+            if (removeFromSet)
+            {
+                tags.Remove(tag);
+            }
+            else
+            {
+                tags.Add(tag);
+            }
+            _snapshot = new Snapshot(snapshot.LogTypeEnabled, tags);
             return this;
         }
 

--- a/src/Runtime/Services/Formatter.cs
+++ b/src/Runtime/Services/Formatter.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Text;
 using UnityEngine;
 
@@ -11,9 +11,20 @@ namespace Appegy.UniLogger
         private const float TagColorValue = 0.8f;
         private const string HexDigits = "0123456789ABCDEF";
 
-        private static readonly Dictionary<string, string> _tagColorHex = new Dictionary<string, string>();
+        private static readonly ConcurrentDictionary<string, string> _tagColorHex = new ConcurrentDictionary<string, string>();
+        private static readonly Func<string, string> _tagColorFactory = ComputeTagColorHex;
 
-        public FormatOptions FormatOptions { get; set; }
+        private FormatOptions _formatOptions;
+
+        public FormatOptions FormatOptions
+        {
+            get => _formatOptions;
+            set
+            {
+                ThreadDispatcher.EnsureMainThread(nameof(FormatOptions));
+                _formatOptions = value;
+            }
+        }
 
         private bool AnyFormat => FormatOptions != FormatOptions.None;
         private bool RichText => FormatOptions.HasFlagFast(FormatOptions.RichText);
@@ -24,7 +35,7 @@ namespace Appegy.UniLogger
 
         public Formatter(FormatOptions options = FormatOptions.None)
         {
-            FormatOptions = options;
+            _formatOptions = options;
         }
 
         public string Format(LogEntry line)
@@ -148,17 +159,14 @@ namespace Appegy.UniLogger
 
         private static string GetTagColorHex(string tag)
         {
-            lock (_tagColorHex)
-            {
-                if (_tagColorHex.TryGetValue(tag, out var hex)) return hex;
+            return _tagColorHex.GetOrAdd(tag, _tagColorFactory);
+        }
 
-                var hue = (StableHash(tag) & 0xFFFFFF) / (float)0x1000000;
-                var color = Color.HSVToRGB(hue, TagColorSaturation, TagColorValue);
-                hex = ColorUtility.ToHtmlStringRGBA(color);
-
-                _tagColorHex[tag] = hex;
-                return hex;
-            }
+        private static string ComputeTagColorHex(string tag)
+        {
+            var hue = (StableHash(tag) & 0xFFFFFF) / (float)0x1000000;
+            var color = Color.HSVToRGB(hue, TagColorSaturation, TagColorValue);
+            return ColorUtility.ToHtmlStringRGBA(color);
         }
 
         private static uint StableHash(string tag)

--- a/src/Runtime/Services/Formatter.cs
+++ b/src/Runtime/Services/Formatter.cs
@@ -11,7 +11,7 @@ namespace Appegy.UniLogger
         private const float TagColorValue = 0.8f;
         private const string HexDigits = "0123456789ABCDEF";
 
-        private static readonly ConcurrentDictionary<string, string> _tagColorHex = new ConcurrentDictionary<string, string>();
+        private static readonly ConcurrentDictionary<string, string> _tagColorHex = new();
         private static readonly Func<string, string> _tagColorFactory = ComputeTagColorHex;
 
         private FormatOptions _formatOptions;

--- a/src/Runtime/Services/Target.cs
+++ b/src/Runtime/Services/Target.cs
@@ -35,12 +35,13 @@ namespace Appegy.UniLogger
             _stackTraceLogType = new bool[LogTypes.Count];
             foreach (var logType in LogTypes)
             {
-                SetStackTraceEnabled(logType, true);
+                _stackTraceLogType[(int)logType] = true;
             }
         }
 
         public void SetStackTraceEnabled(LogLevel logLevel, bool enabled)
         {
+            ThreadDispatcher.EnsureMainThread(nameof(SetStackTraceEnabled));
             _stackTraceLogType[(int)logLevel] = enabled;
         }
 

--- a/src/Runtime/Tag/EnumTagCache.cs
+++ b/src/Runtime/Tag/EnumTagCache.cs
@@ -6,7 +6,7 @@ namespace Appegy.UniLogger
     internal static class EnumTagCache<TEnum>
         where TEnum : struct, Enum
     {
-        private static readonly ConcurrentDictionary<TEnum, string> _cache = new ConcurrentDictionary<TEnum, string>();
+        private static readonly ConcurrentDictionary<TEnum, string> _cache = new();
         private static readonly Func<TEnum, string> _resolve = Resolve;
 
         public static string Get(TEnum value)

--- a/src/Runtime/Tag/TagsHelper.cs
+++ b/src/Runtime/Tag/TagsHelper.cs
@@ -5,8 +5,8 @@ namespace Appegy.UniLogger
 {
     internal static class TagsHelper
     {
-        private static readonly Dictionary<Type, string> _tagTypesCache = new Dictionary<Type, string>();
-        private static readonly Dictionary<Enum, string> _tagEnumsCache = new Dictionary<Enum, string>();
+        private static readonly Dictionary<Type, string> _tagTypesCache = new();
+        private static readonly Dictionary<Enum, string> _tagEnumsCache = new();
 
         public static string GetTag(this object tag)
         {

--- a/src/Runtime/Targets/FileTarget.cs
+++ b/src/Runtime/Targets/FileTarget.cs
@@ -28,7 +28,7 @@ namespace Appegy.UniLogger
             string path,
             long fileSizeLimitBytes = 0,
             int retainedFileCountLimit = 0,
-            bool autoFlush = true,
+            bool autoFlush = false,
             Formatter formatter = null,
             Filterer filterer = null)
             : base(formatter, filterer)

--- a/src/Runtime/Targets/FileTarget.cs
+++ b/src/Runtime/Targets/FileTarget.cs
@@ -82,7 +82,15 @@ namespace Appegy.UniLogger
 
         protected internal override void Flush()
         {
-            FlushWriter();
+            if (_disposed || _writer == null) return;
+            try
+            {
+                _writer.Flush();
+            }
+            catch
+            {
+                // never throw from logging
+            }
         }
 
         public string[] GetLogFiles()
@@ -129,19 +137,6 @@ namespace Appegy.UniLogger
             }
 
             ApplyRetention();
-        }
-
-        private void FlushWriter()
-        {
-            if (_disposed || _writer == null) return;
-            try
-            {
-                _writer.Flush();
-            }
-            catch
-            {
-                // never throw from logging
-            }
         }
 
         private void CloseWriter()

--- a/src/Runtime/Targets/InMemoryTarget.cs
+++ b/src/Runtime/Targets/InMemoryTarget.cs
@@ -6,6 +6,7 @@ namespace Appegy.UniLogger
     {
         private readonly char[] _buffer;
         private readonly int _capacity;
+        private readonly object _gate = new object();
         private int _start;
         private int _count;
 
@@ -19,33 +20,42 @@ namespace Appegy.UniLogger
 
         protected internal override void Log(string message, string stackTrace)
         {
-            Append(message);
-            if (!string.IsNullOrEmpty(stackTrace))
+            lock (_gate)
             {
+                Append(message);
+                if (!string.IsNullOrEmpty(stackTrace))
+                {
+                    Append("\n");
+                    Append(stackTrace);
+                }
                 Append("\n");
-                Append(stackTrace);
             }
-            Append("\n");
         }
 
         public string GetContent()
         {
-            if (_count == 0) return string.Empty;
-            var firstChunk = Math.Min(_count, _capacity - _start);
-            if (firstChunk == _count)
+            lock (_gate)
             {
-                return new string(_buffer, _start, _count);
+                if (_count == 0) return string.Empty;
+                var firstChunk = Math.Min(_count, _capacity - _start);
+                if (firstChunk == _count)
+                {
+                    return new string(_buffer, _start, _count);
+                }
+                var result = new char[_count];
+                Array.Copy(_buffer, _start, result, 0, firstChunk);
+                Array.Copy(_buffer, 0, result, firstChunk, _count - firstChunk);
+                return new string(result);
             }
-            var result = new char[_count];
-            Array.Copy(_buffer, _start, result, 0, firstChunk);
-            Array.Copy(_buffer, 0, result, firstChunk, _count - firstChunk);
-            return new string(result);
         }
 
         public void Clear()
         {
-            _start = 0;
-            _count = 0;
+            lock (_gate)
+            {
+                _start = 0;
+                _count = 0;
+            }
         }
 
         private void Append(string text)

--- a/src/Runtime/Targets/InMemoryTarget.cs
+++ b/src/Runtime/Targets/InMemoryTarget.cs
@@ -6,7 +6,7 @@ namespace Appegy.UniLogger
     {
         private readonly char[] _buffer;
         private readonly int _capacity;
-        private readonly object _gate = new object();
+        private readonly object _gate = new();
         private int _start;
         private int _count;
 

--- a/src/Runtime/Types/LogEntry.cs
+++ b/src/Runtime/Types/LogEntry.cs
@@ -19,6 +19,11 @@ namespace Appegy.UniLogger
         public readonly bool IsColored;
 
         public LogEntry(IReadOnlyList<string> tags, LogLevel logLevel, string message, Color color, Object context)
+            : this(tags, logLevel, message, color, context, DateTime.Now, Thread.CurrentThread.ManagedThreadId)
+        {
+        }
+
+        internal LogEntry(IReadOnlyList<string> tags, LogLevel logLevel, string message, Color color, Object context, DateTime logTime, int threadId)
         {
             Tags = tags;
             LogLevel = logLevel;
@@ -26,8 +31,8 @@ namespace Appegy.UniLogger
             Color = color;
             Context = context;
 
-            LogTime = DateTime.Now;
-            ThreadId = Thread.CurrentThread.ManagedThreadId;
+            LogTime = logTime;
+            ThreadId = threadId;
             IsColored = color != default;
         }
     }

--- a/src/Runtime/Types/LoggerConfig.cs
+++ b/src/Runtime/Types/LoggerConfig.cs
@@ -8,9 +8,9 @@ namespace Appegy.UniLogger
     public class LoggerConfig
     {
         private const string KeyPrefix = nameof(ULogger) + ".Tags.";
-        private readonly ConcurrentDictionary<(string, LogLevel), bool> _loggingLevelCache = new ConcurrentDictionary<(string, LogLevel), bool>();
+        private readonly ConcurrentDictionary<(string, LogLevel), bool> _loggingLevelCache = new();
 
-        internal List<Target> Targets { get; } = new List<Target>();
+        internal List<Target> Targets { get; } = new();
 
         public Formatter UnityFormatter { get; internal set; }
 

--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -159,10 +159,10 @@ namespace Appegy.UniLogger
 
         private static void OnApplicationFocusChanged(bool focused)
         {
-            if (!focused)
-            {
-                Flush();
-            }
+            if (focused) return;
+            var data = Data;
+            if (data == null) return;
+            data.Dispatcher.Flush();
         }
 
         private static void OnLogMessageReceivedThreaded(string condition, string stacktrace, LogType type)
@@ -187,13 +187,6 @@ namespace Appegy.UniLogger
         {
             if (Data == null) return;
             Data.LogHandler.Default.LogException(e.Exception.InnerException ?? e.Exception);
-        }
-
-        public static void Flush()
-        {
-            var data = Data;
-            if (data == null) return;
-            data.Dispatcher.Flush();
         }
 
         #region GetLogger

--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -112,7 +112,6 @@ namespace Appegy.UniLogger
             Debug.unityLogger.logHandler = Data.LogHandler;
             Application.logMessageReceivedThreaded += OnLogMessageReceivedThreaded;
             Application.quitting += Terminate;
-            Application.focusChanged += OnApplicationFocusChanged;
             TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
         }
 
@@ -123,7 +122,6 @@ namespace Appegy.UniLogger
             Debug.unityLogger.logHandler = Data.LogHandler.Default;
             Application.logMessageReceivedThreaded -= OnLogMessageReceivedThreaded;
             Application.quitting -= Terminate;
-            Application.focusChanged -= OnApplicationFocusChanged;
             TaskScheduler.UnobservedTaskException -= OnUnobservedTaskException;
 
             Data.Dispatcher.Dispose();
@@ -135,14 +133,6 @@ namespace Appegy.UniLogger
                 }
             }
             Data = null;
-        }
-
-        private static void OnApplicationFocusChanged(bool focused)
-        {
-            if (focused) return;
-            var data = Data;
-            if (data == null) return;
-            data.Dispatcher.Flush();
         }
 
         private static void OnLogMessageReceivedThreaded(string condition, string stacktrace, LogType type)

--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -93,26 +93,6 @@ namespace Appegy.UniLogger
             }
         }
 
-        public static bool RemoveTarget<T>() where T : Target
-        {
-            ThreadDispatcher.EnsureMainThread(nameof(RemoveTarget));
-            if (Data == null) return false;
-            var removed = Data.RemoveTarget(typeof(T));
-            if (removed == null) return false;
-
-            Data.Dispatcher.Flush();
-
-            if (removed is IDisposable disposable)
-            {
-                disposable.Dispose();
-            }
-            else
-            {
-                removed.Flush();
-            }
-            return true;
-        }
-
         public static void Initialize(Formatter unityFormatter = null, Filterer unityFilterer = null)
         {
             ThreadDispatcher.EnsureMainThread(nameof(Initialize));

--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -31,7 +31,7 @@ namespace Appegy.UniLogger
 #if ULOGGER_DISABLE_ALL_LOGS
         private static readonly ULogger _disabledLogger = new ULogger(Tags.Disabled);
 #else
-        private static readonly ConcurrentDictionary<string, ULogger> _loggersByTag = new ConcurrentDictionary<string, ULogger>();
+        private static readonly ConcurrentDictionary<string, ULogger> _loggersByTag = new();
         private static readonly Func<string, ULogger> _loggerFactory = tag => new ULogger(tag);
 #endif
 

--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -48,6 +48,8 @@ namespace Appegy.UniLogger
             public string ManualStacktrace;
             public Color Color;
             public UnityEngine.Object Context;
+            public DateTime LogTime;
+            public int ThreadId;
         }
 
         [CanBeNull]
@@ -83,6 +85,7 @@ namespace Appegy.UniLogger
         public static void AddTarget<T>(T target) where T : Target
         {
             if (target == null) throw new ArgumentNullException(nameof(target));
+            ThreadDispatcher.EnsureMainThread(nameof(AddTarget));
             if (Data == null) throw new InvalidOperationException($"{nameof(ULogger)}.{nameof(Initialize)} must be called before adding targets.");
             if (!Data.AddTarget(target))
             {
@@ -92,9 +95,13 @@ namespace Appegy.UniLogger
 
         public static bool RemoveTarget<T>() where T : Target
         {
+            ThreadDispatcher.EnsureMainThread(nameof(RemoveTarget));
             if (Data == null) return false;
             var removed = Data.RemoveTarget(typeof(T));
             if (removed == null) return false;
+
+            Data.Dispatcher.Flush();
+
             if (removed is IDisposable disposable)
             {
                 disposable.Dispose();
@@ -108,6 +115,11 @@ namespace Appegy.UniLogger
 
         public static void Initialize(Formatter unityFormatter = null, Filterer unityFilterer = null)
         {
+            ThreadDispatcher.EnsureMainThread(nameof(Initialize));
+            if (Data != null)
+            {
+                Terminate();
+            }
             unityFormatter ??= new Formatter();
             unityFilterer ??= new Filterer(true);
             var unityTarget = new UnityTarget(unityFormatter, unityFilterer);
@@ -116,18 +128,25 @@ namespace Appegy.UniLogger
                 UnityTarget = unityTarget,
                 LogHandler = new UnityLogger(Debug.unityLogger.logHandler),
             };
+            Data.Dispatcher = new LogDispatcher(Data);
             Debug.unityLogger.logHandler = Data.LogHandler;
             Application.logMessageReceivedThreaded += OnLogMessageReceivedThreaded;
+            Application.quitting += Terminate;
+            Application.focusChanged += OnApplicationFocusChanged;
             TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
         }
 
         public static void Terminate()
         {
+            ThreadDispatcher.EnsureMainThread(nameof(Terminate));
             if (Data == null) return;
             Debug.unityLogger.logHandler = Data.LogHandler.Default;
             Application.logMessageReceivedThreaded -= OnLogMessageReceivedThreaded;
+            Application.quitting -= Terminate;
+            Application.focusChanged -= OnApplicationFocusChanged;
             TaskScheduler.UnobservedTaskException -= OnUnobservedTaskException;
-            Flush();
+
+            Data.Dispatcher.Dispose();
             foreach (var target in Data.Targets)
             {
                 if (target is IDisposable disposable)
@@ -136,6 +155,14 @@ namespace Appegy.UniLogger
                 }
             }
             Data = null;
+        }
+
+        private static void OnApplicationFocusChanged(bool focused)
+        {
+            if (!focused)
+            {
+                Flush();
+            }
         }
 
         private static void OnLogMessageReceivedThreaded(string condition, string stacktrace, LogType type)
@@ -147,7 +174,7 @@ namespace Appegy.UniLogger
                 {
                     stacktrace = pending.ManualStacktrace;
                 }
-                BroadcastLog(pending.Data, pending.Tags, pending.LogLevel, pending.Message, stacktrace, pending.Color, pending.Context);
+                pending.Data.Dispatcher.Enqueue(new LogRecord(pending.Tags, pending.LogLevel, pending.Message, stacktrace, pending.Color, pending.Context, pending.LogTime, pending.ThreadId));
             }
             else
             {
@@ -165,11 +192,9 @@ namespace Appegy.UniLogger
 
         public static void Flush()
         {
-            if (Data == null) return;
-            foreach (var target in Data.Targets)
-            {
-                target.Flush();
-            }
+            var data = Data;
+            if (data == null) return;
+            data.Dispatcher.Flush();
         }
 
         #region GetLogger

--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -187,7 +187,6 @@ namespace Appegy.UniLogger
         {
             if (Data == null) return;
             Data.LogHandler.Default.LogException(e.Exception.InnerException ?? e.Exception);
-            Flush();
         }
 
         public static void Flush()

--- a/src/Runtime/ULogger.cs
+++ b/src/Runtime/ULogger.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Appegy.UniLogger
 {
@@ -27,10 +30,13 @@ namespace Appegy.UniLogger
                 return;
             }
 
+            var logTime = DateTime.Now;
+            var threadId = Thread.CurrentThread.ManagedThreadId;
+
             // means it is possible to send log to Unity, catch using Application.logMessageReceivedThreaded and broadcast to other targets
             if (WillBeAllowedByFilterer(Data.UnityTarget.Filterer, logLevel, _tags))
             {
-                var line = new LogEntry(FilterTags(_tags, Data.UnityTarget.Filterer, logLevel), logLevel, message, color, context);
+                var line = new LogEntry(FilterTags(_tags, Data.UnityTarget.Filterer, logLevel), logLevel, message, color, context, logTime, threadId);
                 var formattedMessage = Data.UnityTarget.Formatter.Format(line);
 
                 // manually extract stack trace if stack it disabled by unity (or we are in separate thread) but some target needs it
@@ -51,6 +57,8 @@ namespace Appegy.UniLogger
                     ManualStacktrace = manualStacktrace,
                     Color = color,
                     Context = context,
+                    LogTime = logTime,
+                    ThreadId = threadId,
                 };
                 Data.LogHandler.Default.Log(logLevel.ConvertToLogType(), (object)formattedMessage, context);
                 _pending = null;
@@ -74,7 +82,7 @@ namespace Appegy.UniLogger
                 }
                 if (allowedByAnyFilterer)
                 {
-                    BroadcastLog(Data, _tags, logLevel, message, manualStacktrace, color, context);
+                    Data.Dispatcher.Enqueue(new LogRecord(_tags, logLevel, message, manualStacktrace, color, context, logTime, threadId));
                 }
             }
         }
@@ -95,22 +103,22 @@ namespace Appegy.UniLogger
         {
             if (Data == null) return;
             var logLevel = type.ConvertToLogLevel();
-            BroadcastLog(Data, _tags, logLevel, message, stacktrace, default, default);
+            Data.Dispatcher.Enqueue(new LogRecord(_tags, logLevel, message, stacktrace, default, default, DateTime.Now, Thread.CurrentThread.ManagedThreadId));
         }
 
-        private static void BroadcastLog(ULoggerData data, IReadOnlyList<string> tags, LogLevel logLevel, string message, string stackTrace, Color color, Object context)
+        internal static void Deliver(ULoggerData data, in LogRecord record)
         {
             foreach (var target in data.Targets)
             {
-                if (!WillBeAllowedByFilterer(target.Filterer, logLevel, tags))
+                if (!WillBeAllowedByFilterer(target.Filterer, record.LogLevel, record.Tags))
                 {
                     continue;
                 }
                 try
                 {
-                    var line = new LogEntry(FilterTags(tags, target.Filterer, logLevel), logLevel, message, color, context);
+                    var line = new LogEntry(FilterTags(record.Tags, target.Filterer, record.LogLevel), record.LogLevel, record.Message, record.Color, record.Context, record.LogTime, record.ThreadId);
                     var formattedMessage = target.Formatter.Format(line);
-                    var targetStackTrace = target.GetStackTraceEnabled(line.LogLevel) ? stackTrace : null;
+                    var targetStackTrace = target.GetStackTraceEnabled(record.LogLevel) ? record.StackTrace : null;
                     target.Log(formattedMessage, targetStackTrace);
                 }
                 catch

--- a/src/Runtime/ULoggerData.cs
+++ b/src/Runtime/ULoggerData.cs
@@ -26,23 +26,5 @@ namespace Appegy.UniLogger
             _targets = updated;
             return true;
         }
-
-        public Target RemoveTarget(Type type)
-        {
-            var current = _targets;
-            for (var i = 0; i < current.Length; i++)
-            {
-                if (type.IsInstanceOfType(current[i]))
-                {
-                    var removed = current[i];
-                    var updated = new Target[current.Length - 1];
-                    Array.Copy(current, 0, updated, 0, i);
-                    Array.Copy(current, i + 1, updated, i, current.Length - i - 1);
-                    _targets = updated;
-                    return removed;
-                }
-            }
-            return null;
-        }
     }
 }

--- a/src/Runtime/ULoggerData.cs
+++ b/src/Runtime/ULoggerData.cs
@@ -1,34 +1,44 @@
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Appegy.UniLogger
 {
     internal class ULoggerData
     {
-        public List<Target> Targets { get; } = new List<Target>();
+        private volatile Target[] _targets = Array.Empty<Target>();
+
+        public Target[] Targets => _targets;
         public UnityTarget UnityTarget { get; init; }
         public UnityLogger LogHandler { get; init; }
+        public LogDispatcher Dispatcher { get; set; }
 
         public bool AddTarget(Target target)
         {
             var type = target.GetType();
-            foreach (var existing in Targets)
+            var current = _targets;
+            foreach (var existing in current)
             {
                 if (existing.GetType() == type) return false;
             }
-            Targets.Add(target);
+            var updated = new Target[current.Length + 1];
+            Array.Copy(current, updated, current.Length);
+            updated[current.Length] = target;
+            _targets = updated;
             return true;
         }
 
         public Target RemoveTarget(Type type)
         {
-            for (var i = 0; i < Targets.Count; i++)
+            var current = _targets;
+            for (var i = 0; i < current.Length; i++)
             {
-                if (type.IsInstanceOfType(Targets[i]))
+                if (type.IsInstanceOfType(current[i]))
                 {
-                    var removed = Targets[i];
-                    Targets.RemoveAt(i);
+                    var removed = current[i];
+                    var updated = new Target[current.Length - 1];
+                    Array.Copy(current, 0, updated, 0, i);
+                    Array.Copy(current, i + 1, updated, i, current.Length - i - 1);
+                    _targets = updated;
                     return removed;
                 }
             }

--- a/src/Runtime/Utilities/ThreadDispatcher.cs
+++ b/src/Runtime/Utilities/ThreadDispatcher.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+using System;
+using System.Threading;
 using UnityEngine;
 
 namespace Appegy.UniLogger
@@ -9,10 +10,18 @@ namespace Appegy.UniLogger
 
         public static bool IsMainThread => MainThread != null && MainThread.ManagedThreadId == Thread.CurrentThread.ManagedThreadId;
 
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-        private static void AutoConfigureLogger()
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
+        private static void CaptureMainThread()
         {
             MainThread = Thread.CurrentThread;
+        }
+
+        public static void EnsureMainThread(string operation)
+        {
+            if (MainThread != null && MainThread.ManagedThreadId != Thread.CurrentThread.ManagedThreadId)
+            {
+                throw new InvalidOperationException($"{nameof(ULogger)}.{operation} must be called from the main thread.");
+            }
         }
     }
 }


### PR DESCRIPTION
Logs can now be emitted from any thread. Delivery to custom targets goes through an MPSC queue drained by a single background writer (batch flush, Grow backpressure), so targets need no locks; the Unity console write stays synchronous on the calling thread to preserve console double-click. Logger config (Filterer, target registry, FormatOptions) is main-thread-only with a hard guard and is read via lock-free immutable snapshots.

Behavior notes for review: targets are registered via AddTarget and live until Terminate (no runtime removal); FileTarget.autoFlush defaults to false (the writer owns flush cadence); shutdown drains the queue, and focus-loss flushes it, to avoid losing queued logs. All EditMode tests pass; package, Lab, Editor and Tests assemblies compile clean across the full define matrix.