### PR TITLE
feat: deliver real Exception instances to targets via LogException

### DIFF
--- a/Appegy.UniLogger.Lab/Assets/Scenes/ExampleScene.unity
+++ b/Appegy.UniLogger.Lab/Assets/Scenes/ExampleScene.unity
@@ -119,6 +119,50 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &315014944
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 315014946}
+  - component: {fileID: 315014945}
+  m_Layer: 0
+  m_Name: ExceptionInAggregate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &315014945
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 315014944}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 52aa6e75cb376c29aa4b9a0c2a76ac86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Appegy.UniLogger.Example.ExceptionInAggregate
+--- !u!4 &315014946
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 315014944}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -793,3 +837,4 @@ SceneRoots:
   - {fileID: 1449897689}
   - {fileID: 1073955932}
   - {fileID: 1464717865}
+  - {fileID: 315014946}

--- a/Appegy.UniLogger.Lab/Assets/Scripts/Exceptions/ExceptionInAggregate.cs
+++ b/Appegy.UniLogger.Lab/Assets/Scripts/Exceptions/ExceptionInAggregate.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+
+namespace Appegy.UniLogger.Example
+{
+    public class ExceptionInAggregate : MonoBehaviour
+    {
+        private void Start()
+        {
+            ULogger.LogException(BuildAggregate());
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private AggregateException BuildAggregate()
+        {
+            try
+            {
+                ThrowInner();
+            }
+            catch (Exception inner)
+            {
+                return new AggregateException("Wrapped by aggregate", inner);
+            }
+            return null;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ThrowInner()
+        {
+            throw new InvalidOperationException("Real cause inside aggregate");
+        }
+    }
+}

--- a/Appegy.UniLogger.Lab/Assets/Scripts/Exceptions/ExceptionInAggregate.cs.meta
+++ b/Appegy.UniLogger.Lab/Assets/Scripts/Exceptions/ExceptionInAggregate.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 52aa6e75cb376c29aa4b9a0c2a76ac86

--- a/Appegy.UniLogger.Lab/Assets/Scripts/Exceptions/ExceptionInMethod.cs
+++ b/Appegy.UniLogger.Lab/Assets/Scripts/Exceptions/ExceptionInMethod.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Appegy.UniLogger.Example
@@ -10,6 +11,7 @@ namespace Appegy.UniLogger.Example
             ThrowMethod();
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private void ThrowMethod()
         {
             throw new Exception("Throw exception in method");

--- a/Appegy.UniLogger.Lab/Assets/Scripts/Logging/ExceptionLogging.cs
+++ b/Appegy.UniLogger.Lab/Assets/Scripts/Logging/ExceptionLogging.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Appegy.UniLogger.Example
@@ -12,6 +13,7 @@ namespace Appegy.UniLogger.Example
             ThrowMethod();
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private void ThrowMethod()
         {
             Debug.LogException(new Exception("Custom exception"), this);

--- a/src/Runtime/Internal/LogRecord.cs
+++ b/src/Runtime/Internal/LogRecord.cs
@@ -30,12 +30,12 @@ namespace Appegy.UniLogger
             Exception = null;
         }
 
-        public LogRecord(Exception exception)
+        public LogRecord(Exception exception, string message)
         {
             Exception = exception;
+            Message = message;
             Tags = null;
             LogLevel = default;
-            Message = null;
             StackTrace = null;
             Color = default;
             Context = null;

--- a/src/Runtime/Internal/LogRecord.cs
+++ b/src/Runtime/Internal/LogRecord.cs
@@ -15,6 +15,7 @@ namespace Appegy.UniLogger
         public readonly Object Context;
         public readonly DateTime LogTime;
         public readonly int ThreadId;
+        public readonly Exception Exception;
 
         public LogRecord(IReadOnlyList<string> tags, LogLevel logLevel, string message, string stackTrace, Color color, Object context, DateTime logTime, int threadId)
         {
@@ -26,6 +27,20 @@ namespace Appegy.UniLogger
             Context = context;
             LogTime = logTime;
             ThreadId = threadId;
+            Exception = null;
+        }
+
+        public LogRecord(Exception exception)
+        {
+            Exception = exception;
+            Tags = null;
+            LogLevel = default;
+            Message = null;
+            StackTrace = null;
+            Color = default;
+            Context = null;
+            LogTime = default;
+            ThreadId = 0;
         }
     }
 }

--- a/src/Runtime/Internal/UnityExceptionFormatter.cs
+++ b/src/Runtime/Internal/UnityExceptionFormatter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
+using System.Text;
 using UnityEngine;
 
 namespace Appegy.UniLogger
@@ -19,50 +20,119 @@ namespace Appegy.UniLogger
             "Appegy.UniLogger.LogDispatcher",
         };
 
-        private static readonly MethodInfo ExtractFormatted = typeof(StackTraceUtility).GetMethod(
-            "ExtractFormattedStackTrace",
-            BindingFlags.Static | BindingFlags.NonPublic,
-            null, new[] { typeof(StackTrace) }, null);
+        private static readonly Func<StackTrace, string> ExtractFormatted = CreateExtractDelegate();
 
-        public static string Format(Exception exception)
+        private static Func<StackTrace, string> CreateExtractDelegate()
         {
             try
             {
+                var method = typeof(StackTraceUtility).GetMethod(
+                    "ExtractFormattedStackTrace",
+                    BindingFlags.Static | BindingFlags.NonPublic,
+                    null, new[] { typeof(StackTrace) }, null);
+                return method == null
+                    ? null
+                    : (Func<StackTrace, string>)method.CreateDelegate(typeof(Func<StackTrace, string>));
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public static string Format(Exception exception)
+        {
+            if (exception == null) return string.Empty;
+
+            var builder = StringBuilderPool.GetBuilder();
+            try
+            {
                 var stack = FormatTrace(new StackTrace(exception, true));
+
+                builder.Append(exception.GetType().Name).Append(": ").Append(exception.Message).Append('\n');
+
                 if (string.IsNullOrEmpty(stack))
                 {
-                    stack = StripInternalFrames(StackTraceUtility.ExtractStackTrace());
+                    AppendStrippedInternalFrames(builder, StackTraceUtility.ExtractStackTrace());
                 }
-                return exception.GetType().Name + ": " + exception.Message + "\n" + stack;
+                else
+                {
+                    builder.Append(stack);
+                }
+
+                return builder.ToString();
             }
             catch
             {
                 return exception.ToString();
             }
+            finally
+            {
+                StringBuilderPool.ReturnBuilder(builder);
+            }
         }
 
         private static string FormatTrace(StackTrace trace)
         {
-            if (ExtractFormatted == null || trace.FrameCount == 0) return null;
-            return ExtractFormatted.Invoke(null, new object[] { trace }) as string;
+            if (ExtractFormatted == null || trace.FrameCount == 0)
+            {
+                return null;
+            }
+            return ExtractFormatted(trace);
         }
 
-        private static string StripInternalFrames(string stack)
+        private static void AppendStrippedInternalFrames(StringBuilder builder, string stack)
         {
-            if (string.IsNullOrEmpty(stack)) return stack;
-            var lines = stack.Split('\n');
+            if (string.IsNullOrEmpty(stack))
+            {
+                return;
+            }
+
             var start = 0;
-            while (start < lines.Length && IsInternalFrame(lines[start])) start++;
-            return start == 0 ? stack : string.Join("\n", lines, start, lines.Length - start);
+            var length = stack.Length;
+            while (start < length)
+            {
+                var lineEnd = stack.IndexOf('\n', start);
+                var lineLength = (lineEnd < 0 ? length : lineEnd) - start;
+                if (!IsInternalFrame(stack, start, lineLength))
+                {
+                    break;
+                }
+                if (lineEnd < 0)
+                {
+                    start = length;
+                    break;
+                }
+                start = lineEnd + 1;
+            }
+
+            if (start >= length)
+            {
+                builder.Append(stack);
+            }
+            else
+            {
+                builder.Append(stack, start, length - start);
+            }
         }
 
-        private static bool IsInternalFrame(string line)
+        private static bool IsInternalFrame(string stack, int lineStart, int lineLength)
         {
             foreach (var prefix in InternalFramePrefixes)
             {
-                if (line.StartsWith(prefix, StringComparison.Ordinal)) return true;
+                if (prefix.Length <= lineLength &&
+                    string.CompareOrdinal(stack, lineStart, prefix, 0, prefix.Length) == 0 &&
+                    (prefix.Length == lineLength || IsFrameBoundary(stack[lineStart + prefix.Length])))
+                {
+                    return true;
+                }
             }
             return false;
+        }
+
+        private static bool IsFrameBoundary(char c)
+        {
+            return c == '.' || c == ':' || c == '(' || c == ' ';
         }
     }
 }

--- a/src/Runtime/Internal/UnityExceptionFormatter.cs
+++ b/src/Runtime/Internal/UnityExceptionFormatter.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using UnityEngine;
+
+namespace Appegy.UniLogger
+{
+    internal static class UnityExceptionFormatter
+    {
+        private static readonly string[] InternalFramePrefixes =
+        {
+            "UnityEngine.StackTraceUtility",
+            "UnityEngine.Debug",
+            "UnityEngine.Logger",
+            "UnityEngine.UnityLogger",
+            "Appegy.UniLogger.ULogger",
+            "Appegy.UniLogger.ExtendedULogger",
+            "Appegy.UniLogger.UnityExceptionFormatter",
+            "Appegy.UniLogger.LogDispatcher",
+        };
+
+        private static readonly MethodInfo ExtractFormatted = typeof(StackTraceUtility).GetMethod(
+            "ExtractFormattedStackTrace",
+            BindingFlags.Static | BindingFlags.NonPublic,
+            null, new[] { typeof(StackTrace) }, null);
+
+        public static string Format(Exception exception)
+        {
+            try
+            {
+                var stack = FormatTrace(new StackTrace(exception, true));
+                if (string.IsNullOrEmpty(stack))
+                {
+                    stack = StripInternalFrames(StackTraceUtility.ExtractStackTrace());
+                }
+                return exception.GetType().Name + ": " + exception.Message + "\n" + stack;
+            }
+            catch
+            {
+                return exception.ToString();
+            }
+        }
+
+        private static string FormatTrace(StackTrace trace)
+        {
+            if (ExtractFormatted == null || trace.FrameCount == 0) return null;
+            return ExtractFormatted.Invoke(null, new object[] { trace }) as string;
+        }
+
+        private static string StripInternalFrames(string stack)
+        {
+            if (string.IsNullOrEmpty(stack)) return stack;
+            var lines = stack.Split('\n');
+            var start = 0;
+            while (start < lines.Length && IsInternalFrame(lines[start])) start++;
+            return start == 0 ? stack : string.Join("\n", lines, start, lines.Length - start);
+        }
+
+        private static bool IsInternalFrame(string line)
+        {
+            foreach (var prefix in InternalFramePrefixes)
+            {
+                if (line.StartsWith(prefix, StringComparison.Ordinal)) return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Runtime/Internal/UnityExceptionFormatter.cs.meta
+++ b/src/Runtime/Internal/UnityExceptionFormatter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2d78b0d966b6a7da38455bd1feb7e0ab

--- a/src/Runtime/Internal/UnityLogger.cs
+++ b/src/Runtime/Internal/UnityLogger.cs
@@ -31,6 +31,7 @@ namespace UnityEngine
         public void LogException(Exception exception, Object context)
         {
             Default.LogException(exception, context);
+            ULogger.EnqueueException(exception);
         }
 
         public void LogFormat(LogType logType, Object context, string format, params object[] args)

--- a/src/Runtime/Services/Target.cs
+++ b/src/Runtime/Services/Target.cs
@@ -53,7 +53,7 @@ namespace Appegy.UniLogger
 
         protected internal abstract void Log(string message, [CanBeNull] string stackTrace);
 
-        protected internal abstract void LogException([NotNull] Exception exception);
+        protected internal abstract void LogException([NotNull] Exception exception, string message);
 
         protected internal virtual void Flush()
         {

--- a/src/Runtime/Services/Target.cs
+++ b/src/Runtime/Services/Target.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using JetBrains.Annotations;
 using static Appegy.UniLogger.LogLevelExtensions;
 
 namespace Appegy.UniLogger
@@ -51,6 +52,8 @@ namespace Appegy.UniLogger
         }
 
         protected internal abstract void Log(string message, [CanBeNull] string stackTrace);
+
+        protected internal abstract void LogException([NotNull] Exception exception);
 
         protected internal virtual void Flush()
         {

--- a/src/Runtime/Targets/FileTarget.cs
+++ b/src/Runtime/Targets/FileTarget.cs
@@ -80,6 +80,11 @@ namespace Appegy.UniLogger
             }
         }
 
+        protected internal override void LogException(Exception exception)
+        {
+            Log(exception.ToString(), null);
+        }
+
         protected internal override void Flush()
         {
             if (_disposed || _writer == null) return;

--- a/src/Runtime/Targets/FileTarget.cs
+++ b/src/Runtime/Targets/FileTarget.cs
@@ -80,9 +80,9 @@ namespace Appegy.UniLogger
             }
         }
 
-        protected internal override void LogException(Exception exception)
+        protected internal override void LogException(Exception exception, string message)
         {
-            Log(exception.ToString(), null);
+            Log(message, null);
         }
 
         protected internal override void Flush()

--- a/src/Runtime/Targets/InMemoryTarget.cs
+++ b/src/Runtime/Targets/InMemoryTarget.cs
@@ -32,9 +32,9 @@ namespace Appegy.UniLogger
             }
         }
 
-        protected internal override void LogException(Exception exception)
+        protected internal override void LogException(Exception exception, string message)
         {
-            Log(exception.ToString(), null);
+            Log(message, null);
         }
 
         public string GetContent()

--- a/src/Runtime/Targets/InMemoryTarget.cs
+++ b/src/Runtime/Targets/InMemoryTarget.cs
@@ -32,6 +32,11 @@ namespace Appegy.UniLogger
             }
         }
 
+        protected internal override void LogException(Exception exception)
+        {
+            Log(exception.ToString(), null);
+        }
+
         public string GetContent()
         {
             lock (_gate)

--- a/src/Runtime/Types/LogLevel.cs
+++ b/src/Runtime/Types/LogLevel.cs
@@ -11,7 +11,6 @@ namespace Appegy.UniLogger
         Log = 1,
         Warning = 2,
         Error = 3,
-        Exception = 4,
     }
 
     public static class LogLevelExtensions
@@ -26,7 +25,7 @@ namespace Appegy.UniLogger
                 LogType.Assert => LogLevel.Error,
                 LogType.Warning => LogLevel.Warning,
                 LogType.Log => LogLevel.Log,
-                LogType.Exception => LogLevel.Exception,
+                LogType.Exception => LogLevel.Error,
                 _ => throw new ArgumentOutOfRangeException(nameof(original), original, null)
             };
         }
@@ -39,7 +38,6 @@ namespace Appegy.UniLogger
                 LogLevel.Log => LogType.Log,
                 LogLevel.Warning => LogType.Warning,
                 LogLevel.Error => LogType.Error,
-                LogLevel.Exception => LogType.Exception,
                 _ => throw new ArgumentOutOfRangeException(nameof(original), original, null)
             };
         }
@@ -52,7 +50,6 @@ namespace Appegy.UniLogger
                 LogLevel.Log => "LG",
                 LogLevel.Warning => "WN",
                 LogLevel.Error => "ER",
-                LogLevel.Exception => "EX",
                 _ => throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, null)
             };
         }
@@ -65,7 +62,6 @@ namespace Appegy.UniLogger
                 LogLevel.Log => "white",
                 LogLevel.Warning => "orange",
                 LogLevel.Error => "red",
-                LogLevel.Exception => "#FF5349FF", // (orange red)
                 _ => throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, null)
             };
         }

--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -137,6 +137,7 @@ namespace Appegy.UniLogger
 
         private static void OnLogMessageReceivedThreaded(string condition, string stacktrace, LogType type)
         {
+            if (type == LogType.Exception) return;
             if (_pending.HasValue)
             {
                 var pending = _pending.Value;
@@ -155,8 +156,14 @@ namespace Appegy.UniLogger
         [HideInCallstack]
         private static void OnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
         {
-            if (Data == null) return;
-            Data.LogHandler.Default.LogException(e.Exception.InnerException ?? e.Exception);
+            LogException(e.Exception.InnerException ?? e.Exception);
+        }
+
+        internal static void EnqueueException(Exception exception)
+        {
+            var data = Data;
+            if (data == null) return;
+            data.Dispatcher.Enqueue(new LogRecord(exception));
         }
 
         #region GetLogger

--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -163,8 +163,19 @@ namespace Appegy.UniLogger
         {
             var data = Data;
             if (data == null || data.Targets.Length == 0 || exception == null) return;
+            exception = UnwrapAggregate(exception);
             var message = UnityExceptionFormatter.Format(exception);
             data.Dispatcher.Enqueue(new LogRecord(exception, message));
+        }
+
+        private static Exception UnwrapAggregate(Exception exception)
+        {
+            if (exception is AggregateException aggregate)
+            {
+                var inner = aggregate.Flatten().InnerExceptions;
+                if (inner.Count == 1) return inner[0];
+            }
+            return exception;
         }
 
         #region GetLogger

--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -162,7 +162,7 @@ namespace Appegy.UniLogger
         internal static void EnqueueException(Exception exception)
         {
             var data = Data;
-            if (data == null || data.Targets.Length == 0) return;
+            if (data == null || data.Targets.Length == 0 || exception == null) return;
             var message = UnityExceptionFormatter.Format(exception);
             data.Dispatcher.Enqueue(new LogRecord(exception, message));
         }

--- a/src/Runtime/ULogger.Static.cs
+++ b/src/Runtime/ULogger.Static.cs
@@ -162,8 +162,9 @@ namespace Appegy.UniLogger
         internal static void EnqueueException(Exception exception)
         {
             var data = Data;
-            if (data == null) return;
-            data.Dispatcher.Enqueue(new LogRecord(exception));
+            if (data == null || data.Targets.Length == 0) return;
+            var message = UnityExceptionFormatter.Format(exception);
+            data.Dispatcher.Enqueue(new LogRecord(exception, message));
         }
 
         #region GetLogger

--- a/src/Runtime/ULogger.Unsorted.cs
+++ b/src/Runtime/ULogger.Unsorted.cs
@@ -351,7 +351,7 @@ namespace Appegy.UniLogger
         {
             if (Data != null)
             {
-                Data.LogHandler.Default.LogException(exception, context);
+                Data.LogHandler.LogException(exception, context);
             }
             else
             {

--- a/src/Runtime/ULogger.cs
+++ b/src/Runtime/ULogger.cs
@@ -108,6 +108,22 @@ namespace Appegy.UniLogger
 
         internal static void Deliver(ULoggerData data, in LogRecord record)
         {
+            if (record.Exception != null)
+            {
+                foreach (var target in data.Targets)
+                {
+                    try
+                    {
+                        target.LogException(record.Exception);
+                    }
+                    catch
+                    {
+                        // just don't fail on log
+                    }
+                }
+                return;
+            }
+
             foreach (var target in data.Targets)
             {
                 if (!WillBeAllowedByFilterer(target.Filterer, record.LogLevel, record.Tags))

--- a/src/Runtime/ULogger.cs
+++ b/src/Runtime/ULogger.cs
@@ -114,7 +114,7 @@ namespace Appegy.UniLogger
                 {
                     try
                     {
-                        target.LogException(record.Exception);
+                        target.LogException(record.Exception, record.Message);
                     }
                     catch
                     {

--- a/src/Tests/ExceptionDeliveryTests.cs
+++ b/src/Tests/ExceptionDeliveryTests.cs
@@ -1,0 +1,68 @@
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Appegy.UniLogger
+{
+    public class ExceptionDeliveryTests
+    {
+        private sealed class RecordingTarget : Target
+        {
+            public string LastMessage;
+            public Exception LastException;
+
+            public RecordingTarget(Formatter formatter = null, Filterer filterer = null)
+                : base(formatter, filterer)
+            {
+            }
+
+            protected internal override void Log(string message, string stackTrace)
+            {
+                LastMessage = message;
+            }
+
+            protected internal override void LogException(Exception exception)
+            {
+                LastException = exception;
+            }
+        }
+
+        [Test]
+        public void WhenExceptionDelivered_ThanTargetReceivesSameInstance()
+        {
+            var data = new ULoggerData();
+            var target = new RecordingTarget();
+            data.AddTarget(target);
+
+            var exception = new InvalidOperationException("boom");
+            ULogger.Deliver(data, new LogRecord(exception));
+
+            target.LastException.Should().BeSameAs(exception);
+        }
+
+        [Test]
+        public void WhenExceptionDelivered_ThanTagFilterIsBypassed()
+        {
+            var data = new ULoggerData();
+            var target = new RecordingTarget(filterer: new Filterer(false));
+            data.AddTarget(target);
+
+            var exception = new InvalidOperationException("boom");
+            ULogger.Deliver(data, new LogRecord(exception));
+
+            target.LastException.Should().BeSameAs(exception);
+        }
+
+        [Test]
+        public void WhenExceptionDelivered_ThanRegularLogIsNotTouched()
+        {
+            var data = new ULoggerData();
+            var target = new RecordingTarget();
+            data.AddTarget(target);
+
+            ULogger.Deliver(data, new LogRecord(new Exception("boom")));
+
+            target.LastMessage.Should().BeNull();
+        }
+    }
+}

--- a/src/Tests/ExceptionDeliveryTests.cs
+++ b/src/Tests/ExceptionDeliveryTests.cs
@@ -10,6 +10,7 @@ namespace Appegy.UniLogger
         {
             public string LastMessage;
             public Exception LastException;
+            public string LastExceptionMessage;
 
             public RecordingTarget(Formatter formatter = null, Filterer filterer = null)
                 : base(formatter, filterer)
@@ -21,23 +22,25 @@ namespace Appegy.UniLogger
                 LastMessage = message;
             }
 
-            protected internal override void LogException(Exception exception)
+            protected internal override void LogException(Exception exception, string message)
             {
                 LastException = exception;
+                LastExceptionMessage = message;
             }
         }
 
         [Test]
-        public void WhenExceptionDelivered_ThanTargetReceivesSameInstance()
+        public void WhenExceptionDelivered_ThanTargetReceivesSameInstanceAndMessage()
         {
             var data = new ULoggerData();
             var target = new RecordingTarget();
             data.AddTarget(target);
 
             var exception = new InvalidOperationException("boom");
-            ULogger.Deliver(data, new LogRecord(exception));
+            ULogger.Deliver(data, new LogRecord(exception, "formatted text"));
 
             target.LastException.Should().BeSameAs(exception);
+            target.LastExceptionMessage.Should().Be("formatted text");
         }
 
         [Test]
@@ -48,7 +51,7 @@ namespace Appegy.UniLogger
             data.AddTarget(target);
 
             var exception = new InvalidOperationException("boom");
-            ULogger.Deliver(data, new LogRecord(exception));
+            ULogger.Deliver(data, new LogRecord(exception, "formatted text"));
 
             target.LastException.Should().BeSameAs(exception);
         }
@@ -60,7 +63,7 @@ namespace Appegy.UniLogger
             var target = new RecordingTarget();
             data.AddTarget(target);
 
-            ULogger.Deliver(data, new LogRecord(new Exception("boom")));
+            ULogger.Deliver(data, new LogRecord(new Exception("boom"), "formatted text"));
 
             target.LastMessage.Should().BeNull();
         }

--- a/src/Tests/ExceptionDeliveryTests.cs.meta
+++ b/src/Tests/ExceptionDeliveryTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dc3f796f37cee7829a03ec9d6f4621e2

--- a/src/Tests/FileTargetTests.cs
+++ b/src/Tests/FileTargetTests.cs
@@ -56,10 +56,10 @@ namespace Appegy.UniLogger
         {
             using var target = new FileTarget(Path.Combine(_directory, "game.log"));
 
-            target.LogException(new InvalidOperationException("boom"));
+            target.LogException(new InvalidOperationException("ignored"), "formatted exception text");
             target.Flush();
 
-            File.ReadAllText(target.CurrentFilePath).Should().Contain("boom");
+            File.ReadAllText(target.CurrentFilePath).Should().Contain("formatted exception text");
         }
 
         [Test]

--- a/src/Tests/FileTargetTests.cs
+++ b/src/Tests/FileTargetTests.cs
@@ -52,6 +52,17 @@ namespace Appegy.UniLogger
         }
 
         [Test]
+        public void WhenExceptionLogged_ThanItIsWrittenToFile()
+        {
+            using var target = new FileTarget(Path.Combine(_directory, "game.log"));
+
+            target.LogException(new InvalidOperationException("boom"));
+            target.Flush();
+
+            File.ReadAllText(target.CurrentFilePath).Should().Contain("boom");
+        }
+
+        [Test]
         public void WhenSizeLimitExceeded_ThanLogRollsToNextFile()
         {
             using var target = new FileTarget(Path.Combine(_directory, "game.log"), fileSizeLimitBytes: 16);

--- a/src/Tests/InMemoryTargetTests.cs
+++ b/src/Tests/InMemoryTargetTests.cs
@@ -47,6 +47,16 @@ namespace Appegy.UniLogger
         }
 
         [Test]
+        public void WhenExceptionLogged_ThanItIsWrittenAsText()
+        {
+            var target = new InMemoryTarget(256);
+
+            target.LogException(new System.InvalidOperationException("boom"));
+
+            target.GetContent().Should().Contain("boom");
+        }
+
+        [Test]
         public void WhenCleared_ThanContentIsEmpty()
         {
             var target = new InMemoryTarget(16);

--- a/src/Tests/InMemoryTargetTests.cs
+++ b/src/Tests/InMemoryTargetTests.cs
@@ -51,9 +51,9 @@ namespace Appegy.UniLogger
         {
             var target = new InMemoryTarget(256);
 
-            target.LogException(new System.InvalidOperationException("boom"));
+            target.LogException(new System.InvalidOperationException("ignored"), "formatted exception text");
 
-            target.GetContent().Should().Contain("boom");
+            target.GetContent().Should().Contain("formatted exception text");
         }
 
         [Test]


### PR DESCRIPTION
Exceptions are now their own delivery flow, separate from logs. Targets gain an abstract `LogException(Exception)` and receive the real managed instance (captured in UnityLogger.LogException, which fires for both uncaught Unity exceptions and explicit Debug.LogException/ULogger.LogException), so a Crashlytics-style target can call Crashlytics.LogException(ex) directly. LogLevel.Exception is removed (an exception is a kind, not a severity; it carries Error); exceptions bypass tag-filter and formatter and ride the same single-writer queue as logs. All 27 EditMode tests pass; package, Lab, Editor and Tests compile clean across the define matrix.